### PR TITLE
Bugfix/odata obfuscation

### DIFF
--- a/Heine.Mvc.ActionFilters.Tests/Extensions/HttpContentExtensionsTests.cs
+++ b/Heine.Mvc.ActionFilters.Tests/Extensions/HttpContentExtensionsTests.cs
@@ -227,6 +227,28 @@ namespace Heine.Mvc.ActionFilters.Tests.Extensions
             }
         }
 
+        [TestCase("name", ODataValueContent)]
+        public void Obfuscate_SamePropertyInsideAndOutsideOfValueArray_OData(string obfuscateValue, string jsonContent)
+        {
+            // Arrange
+            httpResponseMessage.Headers.TryAddWithoutValidation("X-Obfuscate", new List<string> { "Name" });
+            httpResponseMessage.Content = new StringContent(jsonContent);
+            httpResponseMessage.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+            // Act
+            var content = httpResponseMessage.Content.ReadAsString(httpResponseMessage.Headers, true);
+            var obj = JObject.Parse(content);
+
+            // Assert
+            obj.Should().NotBeNull();
+            obj[obfuscateValue].Value<string>().Should().Be(ObfuscateValue);
+            obj["value"].Should().NotBeNull();
+            foreach (var item in obj["value"])
+            {
+                item[obfuscateValue].Value<string>().Should().Be(ObfuscateValue);
+            }
+        }
+
         private const string PascalCaseContent =
             "{\"CaseNumber\":\"2017/901674\",\"CaseHandler\":\"hefur\",\"Document\":\"0AE132314QFQESA\",\"Title\":\"IntegrationTestDocument\",\"JournalTitle\":\"IntegrationTestDocument\",\"Format\":\"pdf\",\"AccountName\":\"TestAccount\",\"AccountId\":\"923313850\",\"Type\":\"Outgoing\",\"Private\":{\"Name\":\"PetterPettersen\",\"AccountNo\":\"123456789\"},\"ExternalRecipients\":[{\"Account\":{\"Name\":\"PålFredriksen\",\"AccountNo\":\"987654321\"},\"Relationships\":[{\"Name\":\"Hansen\"},{\"Tlf\":\"92247789\"}],\"AccountId\":\"923313850\",\"IsCopyRecipient\":false,\"FullName\":\"PålFredriksen\",\"EmailAddress\":\"test1@test.net\",\"Mobile\":\"92247881\"},{\"Account\":{\"Name\":\"PålHansen\",\"AccountNo\":\"852741369\"},\"Relationships\":[{\"Name\":\"Hansen\"},{\"Tlf\":\"92247789\"}],\"AccountId\":\"923313851\",\"IsCopyRecipient\":false,\"FullName\":\"PålHansen\",\"EmailAddress\":\"test2@test.net\",\"Mobile\":\"92247882\"}],\"InternalRecipients\":[{\"Username\":\"hefur\",\"IsCopyRecipient\":false,\"ExemptFromPublic\":true}],\"AccessCode\":\"UO\",\"JournalStatus\":\"F\"}";
 
@@ -240,7 +262,7 @@ namespace Heine.Mvc.ActionFilters.Tests.Extensions
             "[{\"caseNumber\":\"2017/901674\",\"caseHandler\":\"hefur\",\"document\":\"0AE132314QFQESA\",\"title\":\"Integration Test Document\",\"journalTitle\":\"Integration Test Document\",\"format\":\"pdf\",\"accountName\":\"Test Account\",\"accountId\":\"923313850\",\"type\":\"Outgoing\",\"private\":{\"name\":\"Petter Pettersen\",\"accountNo\":\"123456789\"},\"externalRecipients\":[{\"account \":{\"name\":\"Pål Fredriksen\",\"accountNo\":\"987654321\"},\"relationships\":[{\"name\":\"Hansen\"},{\"tlf\":\"92247789\"}],\"accountId\":\"923313850\",\"isCopyRecipient\":false,\"fullName\":\"Pål Fredriksen\",\"emailAddress\":\"test1@test.net\",\"mobile\":\"92247881\"},{\"account \":{\"name\":\"Pål Hansen\",\"accountNo\":\"852741369\"},\"relationships\":[{\"name\":\"Hansen\"},{\"tlf\":\"92247789\"}],\"accountId\":\"923313851\",\"isCopyRecipient\":false,\"fullName\":\"Pål Hansen\",\"emailAddress\":\"test2@test.net\",\"mobile\":\"92247882\"}],\"internalRecipients\":[{\"username\":\"hefur\",\"isCopyRecipient\":false,\"exemptFromPublic\":true}],\"accessCode\":\"UO\",\"journalStatus\":\"F\"}]";
 
         private const string ODataValueContent =
-            "{\"@odata.context\":\"some context\",\"value\":[{\"title\":\"Kredittsjekk - 15.05.2019\",\"format\":\"PDF\",\"archiveReference\":{\"id\":\"959160ff-3563-462a-96de-88b0713bf248\",\"archiveDocumentId\":1495448,\"journalId\":824435,\"caseId\":158036,\"name\":\"Kredittsjekk - 15.05.2019\",\"version\":1,\"archivedOn\":\"2019-05-15T08:35:45.0697052Z\",\"documentDirection\":\"Internal\"},\"children\":[]},{\"title\":\"Søknad om tradisjonell bruksutbygging\",\"format\":\"HTML\",\"archiveReference\":{\"id\":\"f453a994-9c4a-4098-b482-d14b5651b497\",\"archiveDocumentId\":1495446,\"journalId\":824434,\"caseId\":158036,\"name\":\"Søknad om tradisjonell bruksutbygging\",\"version\":1,\"archivedOn\":\"2019-05-15T08:35:22.1412998Z\",\"documentDirection\":\"Incoming\"},\"children\":[{\"id\":\"cf0862c9-8285-4756-9f9d-2fb8122e1f83\",\"ownerId\":\"0e85a952-8333-4dd0-a6cc-e5f67fa8684b\",\"regardingId\":\"0e85a952-8333-4dd0-a6cc-e5f67fa8684b\",\"regardingEntity\":\"ci_application\",\"format\":\"pdf\",\"title\":\"GPL License Terms.pdf\",\"content\":\"JVBERi0xLjQNJeLjz9MNCjE\",\"type\":\"Attachment\",\"parentId\":\"f453a994-9c4a-4098-b482-d14b5651b497\",\"revision\":0,\"revisionOfId\":null,\"createdOn\":\"2019-05-15T08:34:27.2572211Z\",\"modifiedOn\":\"2019-05-15T08:34:27.2572211Z\",\"createdBy\":\"59ece3d7-2478-441a-98b6-bba58adf9304\",\"modifiedBy\":\"59ece3d7-2478-441a-98b6-bba58adf9304\",\"archiveReference\":{\"id\":\"cf0862c9-8285-4756-9f9d-2fb8122e1f83\",\"archiveDocumentId\":1495447,\"journalId\":824434,\"caseId\":0,\"name\":\"GPL License Terms.pdf\",\"version\":0,\"archivedOn\":\"2019-05-15T10:35:23.173925Z\",\"documentDirection\":\"Incoming\"},\"relationships\":[{\"name\":\"Petter Pettersen\",\"accountNo\":\"12345678\"},{\"name\":\"Petter Tork\",\"accountNo\":\"9876542\"}]}]}]}";
+            "{\"@odata.context\":\"some context\",\"name\":\"Petter Olsen\",\"value\":[{\"title\":\"Kredittsjekk - 15.05.2019\",\"format\":\"PDF\",\"archiveReference\":{\"id\":\"959160ff-3563-462a-96de-88b0713bf248\",\"archiveDocumentId\":1495448,\"journalId\":824435,\"caseId\":158036,\"name\":\"Kredittsjekk - 15.05.2019\",\"version\":1,\"archivedOn\":\"2019-05-15T08:35:45.0697052Z\",\"documentDirection\":\"Internal\"},\"name\":\"Petter Olsen\",\"children\":[]},{\"title\":\"Søknad om tradisjonell bruksutbygging\",\"format\":\"HTML\",\"archiveReference\":{\"id\":\"f453a994-9c4a-4098-b482-d14b5651b497\",\"archiveDocumentId\":1495446,\"journalId\":824434,\"caseId\":158036,\"name\":\"Søknad om tradisjonell bruksutbygging\",\"version\":1,\"archivedOn\":\"2019-05-15T08:35:22.1412998Z\",\"documentDirection\":\"Incoming\"},\"name\":\"Petter Olsen\",\"children\":[{\"id\":\"cf0862c9-8285-4756-9f9d-2fb8122e1f83\",\"ownerId\":\"0e85a952-8333-4dd0-a6cc-e5f67fa8684b\",\"regardingId\":\"0e85a952-8333-4dd0-a6cc-e5f67fa8684b\",\"regardingEntity\":\"ci_application\",\"format\":\"pdf\",\"title\":\"GPL License Terms.pdf\",\"content\":\"JVBERi0xLjQNJeLjz9MNCjE\",\"type\":\"Attachment\",\"parentId\":\"f453a994-9c4a-4098-b482-d14b5651b497\",\"revision\":0,\"revisionOfId\":null,\"createdOn\":\"2019-05-15T08:34:27.2572211Z\",\"modifiedOn\":\"2019-05-15T08:34:27.2572211Z\",\"createdBy\":\"59ece3d7-2478-441a-98b6-bba58adf9304\",\"modifiedBy\":\"59ece3d7-2478-441a-98b6-bba58adf9304\",\"archiveReference\":{\"id\":\"cf0862c9-8285-4756-9f9d-2fb8122e1f83\",\"archiveDocumentId\":1495447,\"journalId\":824434,\"caseId\":0,\"name\":\"GPL License Terms.pdf\",\"version\":0,\"archivedOn\":\"2019-05-15T10:35:23.173925Z\",\"documentDirection\":\"Incoming\"},\"relationships\":[{\"name\":\"Petter Pettersen\",\"accountNo\":\"12345678\"},{\"name\":\"Petter Tork\",\"accountNo\":\"9876542\"}]}]}]}";
 
         private static string ObfuscateValue => "*** OBFUSCATED ***";
     }

--- a/Heine.Mvc.ActionFilters.Tests/Heine.Mvc.ActionFilters.Tests.csproj
+++ b/Heine.Mvc.ActionFilters.Tests/Heine.Mvc.ActionFilters.Tests.csproj
@@ -101,8 +101,8 @@
     <Compile Include="Extensions\HttpContentExtensionsTests.cs" />
     <Compile Include="Extensions\StringExtensionsTests.cs" />
     <Compile Include="Services\Models\Document.cs" />
-    <Compile Include="Services\ObfuscatorServiceTests.cs" />
     <Compile Include="Services\Models\Person.cs" />
+    <Compile Include="Services\ObfuscatorServiceTests.cs" />
     <Compile Include="ValidationAttributes\GuidNotEmptyAttributeTests.cs" />
     <Compile Include="ActionFilterAttributes\RequestCorrelationAttributeTests.cs" />
     <Compile Include="HttpActionContextFactory.cs" />
@@ -123,6 +123,7 @@
       <Name>Heine.Mvc.ActionFilters</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>

--- a/Heine.Mvc.ActionFilters.Tests/Services/ObfuscatorServiceTests.cs
+++ b/Heine.Mvc.ActionFilters.Tests/Services/ObfuscatorServiceTests.cs
@@ -34,26 +34,26 @@ namespace Heine.Mvc.ActionFilters.Tests.Services
             documentGraph.Should().NotBeEmpty();
             personGraph.Should().NotBeEmpty();
             documentGraph.Count.Should().Be(15);
-            documentGraph.FirstOrDefault(s => s.Contains("Content")).Should().NotBeNullOrEmpty();
-            documentGraph.FirstOrDefault(s => s.Contains("Owner.Mobil")).Should().NotBeNullOrEmpty();
-            documentGraph.FirstOrDefault(s => s.Contains("Owner.BankAccNo")).Should().NotBeNullOrEmpty();
-            documentGraph.FirstOrDefault(s => s.Contains("Persons[*].Mobil")).Should().NotBeNullOrEmpty();
-            documentGraph.FirstOrDefault(s => s.Contains("Persons[*].BankAccNo")).Should().NotBeNullOrEmpty();
-            documentGraph.FirstOrDefault(s => s.Contains("Parent.Content")).Should().NotBeNullOrEmpty();
-            documentGraph.FirstOrDefault(s => s.Contains("Parent.Owner.Mobil")).Should().NotBeNullOrEmpty();
-            documentGraph.FirstOrDefault(s => s.Contains("Parent.Owner.BankAccNo")).Should().NotBeNullOrEmpty();
-            documentGraph.FirstOrDefault(s => s.Contains("Parent.Persons[*].Mobil")).Should().NotBeNullOrEmpty();
-            documentGraph.FirstOrDefault(s => s.Contains("Parent.Persons[*].BankAccNo")).Should().NotBeNullOrEmpty();
-            documentGraph.FirstOrDefault(s => s.Contains("Children[*].Content")).Should().NotBeNullOrEmpty();
-            documentGraph.FirstOrDefault(s => s.Contains("Children[*].Owner.Mobil")).Should().NotBeNullOrEmpty();
-            documentGraph.FirstOrDefault(s => s.Contains("Children[*].Owner.BankAccNo")).Should().NotBeNullOrEmpty();
-            documentGraph.FirstOrDefault(s => s.Contains("Children[*].Persons[*].Mobil")).Should().NotBeNullOrEmpty();
-            documentGraph.FirstOrDefault(s => s.Contains("Children[*].Persons[*].BankAccNo")).Should().NotBeNullOrEmpty();
+            documentGraph.FirstOrDefault(s => s.Equals("Content")).Should().NotBeNullOrEmpty();
+            documentGraph.FirstOrDefault(s => s.Equals("Owner.Mobil")).Should().NotBeNullOrEmpty();
+            documentGraph.FirstOrDefault(s => s.Equals("Owner.BankAccNo")).Should().NotBeNullOrEmpty();
+            documentGraph.FirstOrDefault(s => s.Equals("Persons[*].Mobil")).Should().NotBeNullOrEmpty();
+            documentGraph.FirstOrDefault(s => s.Equals("Persons[*].BankAccNo")).Should().NotBeNullOrEmpty();
+            documentGraph.FirstOrDefault(s => s.Equals("Parent.Content")).Should().NotBeNullOrEmpty();
+            documentGraph.FirstOrDefault(s => s.Equals("Parent.Owner.Mobil")).Should().NotBeNullOrEmpty();
+            documentGraph.FirstOrDefault(s => s.Equals("Parent.Owner.BankAccNo")).Should().NotBeNullOrEmpty();
+            documentGraph.FirstOrDefault(s => s.Equals("Parent.Persons[*].Mobil")).Should().NotBeNullOrEmpty();
+            documentGraph.FirstOrDefault(s => s.Equals("Parent.Persons[*].BankAccNo")).Should().NotBeNullOrEmpty();
+            documentGraph.FirstOrDefault(s => s.Equals("Children[*].Content")).Should().NotBeNullOrEmpty();
+            documentGraph.FirstOrDefault(s => s.Equals("Children[*].Owner.Mobil")).Should().NotBeNullOrEmpty();
+            documentGraph.FirstOrDefault(s => s.Equals("Children[*].Owner.BankAccNo")).Should().NotBeNullOrEmpty();
+            documentGraph.FirstOrDefault(s => s.Equals("Children[*].Persons[*].Mobil")).Should().NotBeNullOrEmpty();
+            documentGraph.FirstOrDefault(s => s.Equals("Children[*].Persons[*].BankAccNo")).Should().NotBeNullOrEmpty();
             personGraph.Count.Should().Be(4);
-            personGraph.FirstOrDefault(s => s.Contains("BankAccNo")).Should().NotBeNullOrEmpty();
-            personGraph.FirstOrDefault(s => s.Contains("Mobil")).Should().NotBeNullOrEmpty();
-            personGraph.FirstOrDefault(s => s.Contains("Documents[*].Content")).Should().NotBeNullOrEmpty();
-            personGraph.FirstOrDefault(s => s.Contains("PrivateDocuments[*].Content")).Should().NotBeNullOrEmpty();
+            personGraph.FirstOrDefault(s => s.Equals("BankAccNo")).Should().NotBeNullOrEmpty();
+            personGraph.FirstOrDefault(s => s.Equals("Mobil")).Should().NotBeNullOrEmpty();
+            personGraph.FirstOrDefault(s => s.Equals("Documents[*].Content")).Should().NotBeNullOrEmpty();
+            personGraph.FirstOrDefault(s => s.Equals("PrivateDocuments[*].Content")).Should().NotBeNullOrEmpty();
         }
 
         [Test]
@@ -72,10 +72,10 @@ namespace Heine.Mvc.ActionFilters.Tests.Services
             documentGraph.Should().NotBeEmpty();
             personGraph.Should().NotBeEmpty();
             documentGraph.Count.Should().Be(1);
-            documentGraph.FirstOrDefault(s => s.Contains("Content")).Should().NotBeNullOrEmpty();
+            documentGraph.FirstOrDefault(s => s.Equals("Content")).Should().NotBeNullOrEmpty();
             personGraph.Count.Should().Be(2);
-            personGraph.FirstOrDefault(s => s.Contains("BankAccNo")).Should().NotBeNullOrEmpty();
-            personGraph.FirstOrDefault(s => s.Contains("Mobil")).Should().NotBeNullOrEmpty();
+            personGraph.FirstOrDefault(s => s.Equals("BankAccNo")).Should().NotBeNullOrEmpty();
+            personGraph.FirstOrDefault(s => s.Equals("Mobil")).Should().NotBeNullOrEmpty();
         }
 
         [Test]

--- a/Heine.Mvc.ActionFilters/Extensions/HttpContentExtensions.cs
+++ b/Heine.Mvc.ActionFilters/Extensions/HttpContentExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -81,35 +82,52 @@ namespace Heine.Mvc.ActionFilters.Extensions
                         if (!tokens.Any())
                             tokens = jToken.SelectTokens($"{jPath.Path}.{property.JsonPathToCamelCase()}");
 
+                        var isOdataValueObfuscated = false;
                         // Trying to select with alternative path because it could be an OData resp.
                         if (!jPath.IsArray && isHttpResponse && !tokens.Any())
-                            tokens = jToken.SelectTokens($"{jPath.Path}.value[*].{property.JsonPathToCamelCase()}");
-
-                        foreach (var token in tokens)
                         {
-                            if (!token.IsNullOrEmpty())
-                            {
-                                // JToken can be of type JArray, JObject, JProperty or JValue.
-                                if (token.Type == JTokenType.Array)
-                                {
-                                    foreach (var obj in token)
-                                    {
-                                        ObfuscateObject(obj);
-                                    }
-                                }
-                                else if (token.Type == JTokenType.Object)
-                                {
-                                    ObfuscateObject(token);
-                                }
-                                else
-                                {
-                                    token.Replace("*** OBFUSCATED ***");
-                                }
-                            }
+                            tokens = jToken.SelectTokens($"{jPath.Path}.value[*].{property.JsonPathToCamelCase()}");
+                            isOdataValueObfuscated = true;
+                        }
+
+                        ObfuscateTokens(tokens);
+
+                        // Edge case where same json property is inside and outside of OData value response.
+                        // Only the property outside of value response will be obfuscated without this code.
+                        if (!isOdataValueObfuscated && tokens.Any() && isHttpResponse && !jPath.IsArray)
+                        {
+                            tokens = jToken.SelectTokens($"{jPath.Path}.value[*].{property.JsonPathToCamelCase()}");
+                            ObfuscateTokens(tokens);
                         }
                     }
                 }
                 return jToken;
+            }
+
+            void ObfuscateTokens(IEnumerable<JToken> tokens)
+            {
+                foreach (var token in tokens)
+                {
+                    if (!token.IsNullOrEmpty())
+                    {
+                        // JToken can be of type JArray, JObject, JProperty or JValue.
+                        if (token.Type == JTokenType.Array)
+                        {
+                            foreach (var obj in token)
+                            {
+                                ObfuscateObject(obj);
+                            }
+                        }
+                        else if (token.Type == JTokenType.Object)
+                        {
+                            ObfuscateObject(token);
+                        }
+                        else
+                        {
+                            token.Replace("*** OBFUSCATED ***");
+                        }
+                    }
+                }
             }
 
             // Obfuscate each property (JProperty) of object (JObject)

--- a/Heine.Mvc.ActionFilters/Extensions/HttpContentExtensions.cs
+++ b/Heine.Mvc.ActionFilters/Extensions/HttpContentExtensions.cs
@@ -81,7 +81,7 @@ namespace Heine.Mvc.ActionFilters.Extensions
                         if (!tokens.Any())
                             tokens = jToken.SelectTokens($"{jPath.Path}.{property.JsonPathToCamelCase()}");
 
-                        // Trying to select with alternative path because it could be an OData req/resp.
+                        // Trying to select with alternative path because it could be an OData resp.
                         if (!jPath.IsArray && isHttpResponse && !tokens.Any())
                             tokens = jToken.SelectTokens($"{jPath.Path}.value[*].{property.JsonPathToCamelCase()}");
 
@@ -121,7 +121,7 @@ namespace Heine.Mvc.ActionFilters.Extensions
                     if (!prop.IsNullOrEmpty())
                     {
                         // Each property will always have one key/value pair.
-                        prop.First.Replace("*** OBFUSCATED ***");
+                        prop.Single().Replace("*** OBFUSCATED ***");
                     }
                 }
             }

--- a/Heine.Mvc.ActionFilters/Services/ObfuscaterService.cs
+++ b/Heine.Mvc.ActionFilters/Services/ObfuscaterService.cs
@@ -118,6 +118,7 @@ namespace Heine.Mvc.ActionFilters.Services
                 foreach (var type in assembly.GetTypes())
                 {
                     var properties = new List<string>();
+                    // Obfuscation attribute on class level.
                     if (Attribute.IsDefined(type, typeof(ObfuscationAttribute)))
                     {
                         foreach (var propertyInfo in type.GetProperties())
@@ -125,6 +126,7 @@ namespace Heine.Mvc.ActionFilters.Services
                             properties.Add(propertyInfo.Name);
                         }
                     }
+                    // Obfuscation attribute on property level.
                     else
                     {
                         AddObfuscateProperties(type, ref properties, null, expandDepth);


### PR DESCRIPTION
Should now support obfuscating the same JSON property inside and outside of OData Value response.
```
Ex:
{
  "name": "Peter"
  "value": [
    {
       "name": "Peter"
    }
  ]
}
```

Both `name` in root and in `value` should be obfuscated.